### PR TITLE
Remove up menu

### DIFF
--- a/common/app/alarm/app.c
+++ b/common/app/alarm/app.c
@@ -3,43 +3,36 @@
 static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-		INC_MOD(PRIV(app)->alarm_current, svc_alarms_n+1);
+		INC_MOD(PRIV(app)->alarm_current, svc_alarms_n);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
-		DEC_MOD(PRIV(app)->alarm_current, svc_alarms_n+1);
+		DEC_MOD(PRIV(app)->alarm_current, svc_alarms_n);
 	}
 	else if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
 		app_exit();
 	}
+
 	svc_lcd_puts(8, "al");
-	if(PRIV(app)->alarm_current == svc_alarms_n) {
-		svc_lcd_puts(0, "----up");
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			PRIV(app)->alarm_current = 0;
-			app_exit();
+
+	svc_alarm_t al;
+	svc_alarm_get(PRIV(app)->alarm_current, &al);
+	svc_lcd_puti(0, 2, al.h);
+	svc_lcd_puti(2, 2, al.m);
+	hal_lcd_seg_set(HAL_LCD_SEG_COLON, 1);
+	if(al.enable) {
+		if(al.days) {
+			svc_lcd_puts(4, "on");
+		}
+		else {
+			svc_lcd_puts(4, "no");
 		}
 	}
 	else {
-		svc_alarm_t al;
-		svc_alarm_get(PRIV(app)->alarm_current, &al);
-		svc_lcd_puti(0, 2, al.h);
-		svc_lcd_puti(2, 2, al.m);
-		hal_lcd_seg_set(HAL_LCD_SEG_COLON, 1);
-		if(al.enable) {
-			if(al.days) {
-				svc_lcd_puts(4, "on");
-			}
-			else {
-				svc_lcd_puts(4, "no");
-			}
-		}
-		else {
-			svc_lcd_puts(4, "of");
-		}
-		svc_lcd_puti(6, 2, PRIV(app)->alarm_current);
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			app_set_view(app, 1);
-		}
+		svc_lcd_puts(4, "of");
+	}
+	svc_lcd_puti(6, 2, PRIV(app)->alarm_current);
+	if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
+		app_set_view(app, 1);
 	}
 }
 

--- a/common/app/alarm/days.c
+++ b/common/app/alarm/days.c
@@ -3,7 +3,7 @@
 void app_app_alarm_days_main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	svc_alarm_t al;
 	svc_alarm_get(PRIV(app_current)->alarm_current, &al);
-		
+
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
 		INC_MOD(PRIV(app)->day_current, 8);
@@ -32,5 +32,4 @@ void app_app_alarm_days_main(uint8_t view, const app_t *app, svc_main_proc_event
 			svc_alarm_set_day(PRIV(app_current)->alarm_current, PRIV(app_current)->day_current, !(al.days & (1<<(PRIV(app)->day_current))));
 		}
 	}
-	
 }

--- a/common/app/alarm/days.c
+++ b/common/app/alarm/days.c
@@ -6,30 +6,26 @@ void app_app_alarm_days_main(uint8_t view, const app_t *app, svc_main_proc_event
 
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-		INC_MOD(PRIV(app)->day_current, 8);
+		INC_MOD(PRIV(app)->day_current, 7);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
-		DEC_MOD(PRIV(app)->day_current, 8);
+		DEC_MOD(PRIV(app)->day_current, 7);
 	}
+	else if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
+		app_set_view(app, 1);
+	}
+
 	svc_lcd_puts(8, "da");
 	svc_lcd_puti(6, 2, PRIV(app_current)->alarm_current);
-	if(PRIV(app)->day_current == 7) {
-		svc_lcd_puts(0, "----up");
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			PRIV(app)->day_current = 0;
-			app_set_view(app, 1);
-		}
+
+	svc_lcd_puts(4, svc_dow_to_string(PRIV(app)->day_current, SVC_LANG_EN));
+	if(al.days & (1<<(PRIV(app)->day_current))) {
+		svc_lcd_puts(2, "on");
 	}
 	else {
-		svc_lcd_puts(4, svc_dow_to_string(PRIV(app)->day_current, SVC_LANG_EN));
-		if(al.days & (1<<(PRIV(app)->day_current))) {
-			svc_lcd_puts(2, "on");
-		}
-		else {
-			svc_lcd_puts(2, "of");
-		}
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			svc_alarm_set_day(PRIV(app_current)->alarm_current, PRIV(app_current)->day_current, !(al.days & (1<<(PRIV(app)->day_current))));
-		}
+		svc_lcd_puts(2, "of");
+	}
+	if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
+		svc_alarm_set_day(PRIV(app_current)->alarm_current, PRIV(app_current)->day_current, !(al.days & (1<<(PRIV(app)->day_current))));
 	}
 }

--- a/common/app/alarm/edit.c
+++ b/common/app/alarm/edit.c
@@ -14,7 +14,6 @@ static void menu_exit(void *ud) {
 	app_set_view(app_current, 0);
 }
 
-
 static int32_t time_get(void *ud) {
 	svc_alarm_t al;
 	svc_alarm_get(PRIV(app_current)->alarm_current, &al);
@@ -70,7 +69,6 @@ static const svc_menu_item_adj_t menu_item_time = {
 	.handler_set = time_set,
 	.handler_draw = time_draw,
 };
-
 
 static uint8_t enable_get(void *ud) {
 	svc_alarm_t al;

--- a/common/app/alarm/edit.c
+++ b/common/app/alarm/edit.c
@@ -1,15 +1,6 @@
 #include "app.h"
-/*
-static const svc_menu_item_adj_t menu_item_cal = {
-	.type = SVC_MENU_ITEM_T_ADJ,
-	.header = "ca",
-	.text = " cal",
-	.digits = 4,
-	.handler_get = cal_get,
-	.handler_set = cal_set,
-};*/
 
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	PRIV(app_current)->edit_menu_state.item_current = 0;
 	app_set_view(app_current, 0);
 }
@@ -94,12 +85,6 @@ static const svc_menu_item_choice_t menu_item_enable = {
 	.handler_draw = draw_current,
 };
 
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
-};
-
 static void days_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, void *user_data) {
 	svc_alarm_t al;
 	svc_alarm_get(PRIV(app_current)->alarm_current, &al);
@@ -177,14 +162,13 @@ static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_time,
 	(void*)&menu_item_enable,
 	(void*)&menu_item_days,
-	(void*)&menu_item_melody,
-	(void*)&menu_item_up,
+	(void*)&menu_item_melody
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item_up,
+	.handler_exit = menu_exit,
 	.header = "ae",
 	.header_pos = 8
 };

--- a/common/app/compass/app.c
+++ b/common/app/compass/app.c
@@ -12,11 +12,11 @@ static void axis_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, vo
 			case 0:
 				v = r.x;
 			break;
-			
+
 			case 1:
 				v = r.y;
 			break;
-			
+
 			case 2:
 				v = r.z;
 			break;
@@ -25,7 +25,6 @@ static void axis_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, vo
 	}
 	svc_lcd_putc(7, 'x'+axis);
 };
-
 
 static const svc_menu_item_text_t menu_item_x = {
 	.type = SVC_MENU_ITEM_T_TEXT,
@@ -89,7 +88,6 @@ static const svc_menu_item_text_t menu_item_cal = {
 	.handler = menu_cal_enter
 };
 
-
 static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_heading,
 	(void*)&menu_item_x,
@@ -109,7 +107,6 @@ static const svc_menu_t menu = {
 static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	svc_menu_run(&menu, &(PRIV(app)->main_menu_state), event);
 }
-
 
 static priv_t priv = {0};
 

--- a/common/app/compass/app.c
+++ b/common/app/compass/app.c
@@ -63,18 +63,11 @@ static const svc_menu_item_text_t menu_item_heading = {
 	.handler_draw = heading_draw,
 };
 
-
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	PRIV(app_current)->main_menu_state.item_current = 0;
 	//app_set_view(app_current, 0);
 	app_exit();
 }
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
-};
 
 static void menu_cal_enter(void *ud) {
 	PRIV(app_current)->main_menu_state.item_current = 0;
@@ -93,13 +86,13 @@ static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_x,
 	(void*)&menu_item_y,
 	(void*)&menu_item_z,
-	(void*)&menu_item_cal,
-	(void*)&menu_item_up,
+	(void*)&menu_item_cal
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
+	.handler_exit = menu_exit,
 	.header = "co",
 	.header_pos = 8
 };

--- a/common/app/compass/cal.c
+++ b/common/app/compass/cal.c
@@ -27,7 +27,6 @@ static int16_t minmax_get_span(minmax_t *mm) {
 	}
 }
 
-
 static void axis_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, void *user_data) {
 	priv_t *p = PRIV(app_current);
 	intptr_t axis = ((intptr_t)user_data)&3;
@@ -45,11 +44,11 @@ static void axis_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, vo
 		case 0:
 			v = fp(&(p->cal_x));
 		break;
-		
+
 		case 1:
 			v = fp(&(p->cal_y));
 		break;
-		
+
 		case 2:
 			v = fp(&(p->cal_z));
 		break;
@@ -57,7 +56,6 @@ static void axis_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, vo
 	svc_lcd_puti_signed(0, 6, CLAMP_ABS(v, 99999));
 	svc_lcd_putc(7, 'x'+axis);
 };
-
 
 static const svc_menu_item_text_t menu_item_x_c = {
 	.type = SVC_MENU_ITEM_T_TEXT,
@@ -115,7 +113,7 @@ static void menu_store(void *ud) {
 		.x0 = minmax_get_center(&(pr->cal_x)),
 		.y0 = minmax_get_center(&(pr->cal_y)),
 		.z0 = minmax_get_center(&(pr->cal_z)),
-		
+
 		.sx = minmax_get_span(&(pr->cal_x)),
 		.sy = minmax_get_span(&(pr->cal_y)),
 		.sz = minmax_get_span(&(pr->cal_z)),

--- a/common/app/compass/cal.c
+++ b/common/app/compass/cal.c
@@ -95,17 +95,10 @@ static const svc_menu_item_text_t menu_item_z_s = {
 	.user_data = (void*)(2|4)
 };
 
-
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	PRIV(app_current)->cal_menu_state.item_current = 0;
 	app_set_view(app_current, 0);
 }
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
-};
 
 static void menu_store(void *ud) {
 	priv_t *pr = PRIV(app_current);
@@ -135,13 +128,13 @@ static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_x_s,
 	(void*)&menu_item_y_s,
 	(void*)&menu_item_z_s,
-	(void*)&menu_item_store,
-	(void*)&menu_item_up,
+	(void*)&menu_item_store
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
+	.handler_exit = menu_exit,
 	.header = "cc",
 	.header_pos = 8
 };

--- a/common/app/conf/app.c
+++ b/common/app/conf/app.c
@@ -1,6 +1,6 @@
 #include "app.h"
 
-static void conf_exit(void *ud) {
+static void conf_exit(void) {
 	PRIV(app_current)->st.item_current = 0;
 	app_exit();
 }
@@ -287,12 +287,6 @@ static const svc_menu_item_adj_t menu_item_lcd_contrast = {
 	.handler_set = lcd_contrast_set,
 };
 
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = conf_exit
-};
-
 static void debug_enter(void *ud) {
 	app_set_view(app_current, 1);
 }
@@ -317,14 +311,13 @@ static const svc_menu_item_text_t *menu_items[] = {
 	(void*)&menu_item_backlight_timeout,
 	(void*)&menu_item_backlight_brightness,
 	(void*)&menu_item_lcd_contrast,
-	(void*)&menu_item_debug,
-	(void*)&menu_item_up,
+	(void*)&menu_item_debug
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item_up,
+	.handler_exit = conf_exit,
 	.header = "cf",
 	.header_pos = 8
 };

--- a/common/app/conf/app.c
+++ b/common/app/conf/app.c
@@ -58,7 +58,6 @@ static void keybeep_freq_set(uint8_t dig, int8_t dir, void *user_data) {
 	svc_beep_key_set_freq(va);
 }
 
-
 static const svc_menu_item_adj_t menu_item_keybeep_freq = {
 	.type = SVC_MENU_ITEM_T_ADJ,
 	.header = "kf",
@@ -119,7 +118,6 @@ static void hourbeep_duration_set(uint8_t dig, int8_t dir, void *user_data) {
 	va = CLAMP(va+inc, 1, 100);
 	svc_beep_hour_set_duration(va);
 }
-
 
 static const svc_menu_item_adj_t menu_item_hourbeep_duration = {
 	.type = SVC_MENU_ITEM_T_ADJ,
@@ -259,7 +257,6 @@ static void backlight_brightness_set(uint8_t dig, int8_t dir, void *user_data) {
 	svc_backlight_brightness_set(va);
 }
 
-
 static const svc_menu_item_adj_t menu_item_backlight_brightness = {
 	.type = SVC_MENU_ITEM_T_ADJ,
 	.header = "bb",
@@ -280,7 +277,6 @@ static void lcd_contrast_set(uint8_t dig, int8_t dir, void *user_data) {
 	lcd_contrast = CLAMP(lcd_contrast+inc, 0, 15);
 	hal_lcd_set_contrast(lcd_contrast);
 }
-
 
 static const svc_menu_item_adj_t menu_item_lcd_contrast = {
 	.type = SVC_MENU_ITEM_T_ADJ,

--- a/common/app/conf/debug.c
+++ b/common/app/conf/debug.c
@@ -4,10 +4,10 @@
 void app_app_conf_debug_main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-		INC_MOD(PRIV(app)->debug_item_current, HAL_DEBUG_N+1);
+		INC_MOD(PRIV(app)->debug_item_current, HAL_DEBUG_N);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
-		DEC_MOD(PRIV(app)->debug_item_current, HAL_DEBUG_N+1);
+		DEC_MOD(PRIV(app)->debug_item_current, HAL_DEBUG_N);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
 		app_set_view(app, 0);
@@ -17,15 +17,6 @@ void app_app_conf_debug_main(uint8_t view, const app_t *app, svc_main_proc_event
 		PRIV(app)->debug_value = hal_debug_read(PRIV(app)->debug_item_current);
 	}
 	svc_lcd_puts(8, "db");
-	if(PRIV(app)->debug_item_current == HAL_DEBUG_N) {
-		svc_lcd_puts(0, "----up");
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			app_set_view(app, 0);
-			PRIV(app)->debug_item_current = 0;
-		}
-	}
-	else {
-		svc_lcd_puti(6, 2, PRIV(app)->debug_item_current);
-		svc_lcd_putix(0, 4, PRIV(app)->debug_value);
-	}
+	svc_lcd_puti(6, 2, PRIV(app)->debug_item_current);
+	svc_lcd_putix(0, 4, PRIV(app)->debug_value);
 }

--- a/common/app/countdown/app.c
+++ b/common/app/countdown/app.c
@@ -3,10 +3,10 @@
 static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-		INC_MOD(PRIV(app)->countdown_current, svc_countdowns_n+1);
+		INC_MOD(PRIV(app)->countdown_current, svc_countdowns_n);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
-		DEC_MOD(PRIV(app)->countdown_current, svc_countdowns_n+1);
+		DEC_MOD(PRIV(app)->countdown_current, svc_countdowns_n);
 	}
 	else if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
 		app_exit();
@@ -21,32 +21,23 @@ static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 			svc_countdown_stop(PRIV(app_current)->countdown_current);
 		}
 	}
-	if(PRIV(app)->countdown_current == svc_countdowns_n) {
-		svc_lcd_puts(8, "cd");
-		svc_lcd_puts(0, "----up");
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			PRIV(app)->countdown_current = 0;
-			app_exit();
-		}
+
+	svc_countdown_t cd;
+	svc_countdown_get(PRIV(app)->countdown_current, &cd);
+	svc_lcd_puti(0, 2, cd.h);
+	svc_lcd_puti(2, 2, cd.m);
+	svc_lcd_puti(4, 2, cd.s);
+	hal_lcd_seg_set(HAL_LCD_SEG_COLON, 1);
+	hal_lcd_seg_set_blink(HAL_LCD_SEG_COLON, cd.state == SVC_COUNTDOWN_STATE_RUN);
+	if(cd.state == SVC_COUNTDOWN_STATE_RUN) {
+		svc_lcd_puts(8, "ru");
 	}
 	else {
-		svc_countdown_t cd;
-		svc_countdown_get(PRIV(app)->countdown_current, &cd);
-		svc_lcd_puti(0, 2, cd.h);
-		svc_lcd_puti(2, 2, cd.m);
-		svc_lcd_puti(4, 2, cd.s);
-		hal_lcd_seg_set(HAL_LCD_SEG_COLON, 1);
-		hal_lcd_seg_set_blink(HAL_LCD_SEG_COLON, cd.state == SVC_COUNTDOWN_STATE_RUN);
-		if(cd.state == SVC_COUNTDOWN_STATE_RUN) {
-			svc_lcd_puts(8, "ru");
-		}
-		else {
-			svc_lcd_puts(8, "st");
-		}
-		svc_lcd_puti(6, 2, PRIV(app)->countdown_current);
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			app_set_view(app, 1);
-		}
+		svc_lcd_puts(8, "st");
+	}
+	svc_lcd_puti(6, 2, PRIV(app)->countdown_current);
+	if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
+		app_set_view(app, 1);
 	}
 }
 

--- a/common/app/countdown/app.c
+++ b/common/app/countdown/app.c
@@ -48,7 +48,6 @@ static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 			app_set_view(app, 1);
 		}
 	}
-	
 }
 
 static app_view_t views[] = {

--- a/common/app/countdown/edit.c
+++ b/common/app/countdown/edit.c
@@ -9,7 +9,7 @@ static const svc_menu_item_adj_t menu_item_cal = {
 	.handler_set = cal_set,
 };*/
 
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	PRIV(app_current)->edit_menu_state.item_current = 0;
 	app_set_view(app_current, 0);
 }
@@ -72,12 +72,6 @@ static const svc_menu_item_adj_t menu_item_time = {
 	.handler_get = time_get,
 	.handler_set = time_set,
 	.handler_draw = time_draw,
-};
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
 };
 
 static void start_stop_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, void *user_data) {
@@ -144,14 +138,13 @@ static svc_menu_item_choice_t menu_item_melody = {
 static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_start_stop,
 	(void*)&menu_item_time,
-	(void*)&menu_item_melody,
-	(void*)&menu_item_up,
+	(void*)&menu_item_melody
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item_up,
+	.handler_exit = menu_exit,
 	.header = "ce",
 	.header_pos = 8
 };

--- a/common/app/countdown/edit.c
+++ b/common/app/countdown/edit.c
@@ -14,7 +14,6 @@ static void menu_exit(void *ud) {
 	app_set_view(app_current, 0);
 }
 
-
 static int32_t time_get(void *ud) {
 	svc_countdown_t cd;
 	svc_countdown_get(PRIV(app_current)->countdown_current, &cd);

--- a/common/app/launcher/app.c
+++ b/common/app/launcher/app.c
@@ -16,6 +16,11 @@ static void launch(void *papp) {
 	app_launch(app);
 }
 
+static void menu_time(void)
+{
+	launch((void *)&app_app_time);
+}
+
 static const svc_menu_item_text_t menu_item0 = {
 	.text = " time",
 	.handler = launch,
@@ -77,7 +82,7 @@ static const svc_menu_item_text_t *menu_items[] = {
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item0,
+	.handler_exit = menu_time,
 	.header = "la",
 	.header_pos = 8
 };

--- a/common/app/otp/app.c
+++ b/common/app/otp/app.c
@@ -36,17 +36,11 @@ static const svc_menu_item_adj_t menu_item_unlock = {
 	.handler_draw = draw_lock
 };
 
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	PRIV(app_current)->main_menu_state.item_current = 0;
 	//app_set_view(app_current, 0);
 	app_exit();
 }
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
-};
 
 static void menu_lock(void *ud) {
 	svc_otp_lock();
@@ -75,13 +69,13 @@ static const svc_menu_item_text_t menu_item_items = {
 static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_unlock,
 	(void*)&menu_item_items,
-	(void*)&menu_item_lock,
-	(void*)&menu_item_up,
+	(void*)&menu_item_lock
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
+	.handler_exit = menu_exit,
 	.header = "ot",
 	.header_pos = 8
 };

--- a/common/app/otp/items.c
+++ b/common/app/otp/items.c
@@ -3,38 +3,30 @@
 void app_app_otp_items_main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-		INC_MOD(PRIV(app)->item_current, svc_otp_n_items+1);
+		INC_MOD(PRIV(app)->item_current, svc_otp_n_items);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
-		DEC_MOD(PRIV(app)->item_current, svc_otp_n_items+1);
+		DEC_MOD(PRIV(app)->item_current, svc_otp_n_items);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
 		app_set_view(app_current, 0);
 	}
-	if(PRIV(app)->item_current == svc_otp_n_items) {
-		svc_lcd_puts(0, "----up");
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			PRIV(app)->item_current = 0;
-			app_set_view(app_current, 0);
-		}
+
+	svc_lcd_puti(6, 2, svc_otp_get_time_remaining());
+	char label[3];
+	svc_otp_get_label(PRIV(app)->item_current, label);
+	if(label[0]==0) {
+		svc_lcd_puts(0, "------");
+		svc_lcd_puts(8, "--");
 	}
 	else {
-		svc_lcd_puti(6, 2, svc_otp_get_time_remaining());
-		char label[3];
-		svc_otp_get_label(PRIV(app)->item_current, label);
-		if(label[0]==0) {
-			svc_lcd_puts(0, "------");
-			svc_lcd_puts(8, "--");
+		svc_lcd_puts(8, label);
+		int32_t t = svc_otp_get_token(PRIV(app)->item_current);
+		if(t >= 0) {
+			svc_lcd_puti(0, 6, t);
 		}
 		else {
-			svc_lcd_puts(8, label);
-			int32_t t = svc_otp_get_token(PRIV(app)->item_current);
-			if(t >= 0) {
-				svc_lcd_puti(0, 6, t);
-			}
-			else {
-				svc_lcd_puts(0, "------");
-			}
+			svc_lcd_puts(0, "------");
 		}
 	}
 }

--- a/common/app/otp/items.c
+++ b/common/app/otp/items.c
@@ -37,5 +37,4 @@ void app_app_otp_items_main(uint8_t view, const app_t *app, svc_main_proc_event_
 			}
 		}
 	}
-	
 }

--- a/common/app/play/app.c
+++ b/common/app/play/app.c
@@ -15,28 +15,20 @@ typedef struct {
 static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	hal_lcd_clear();
 	if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-		INC_MOD(PRIV(app)->item_current, svc_melodies_n+1);
+		INC_MOD(PRIV(app)->item_current, svc_melodies_n);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
-		DEC_MOD(PRIV(app)->item_current, svc_melodies_n+1);
+		DEC_MOD(PRIV(app)->item_current, svc_melodies_n);
 	}
 	else if (event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
 		app_exit();
 	}
 	svc_lcd_puts(8, "pl");
-	if(PRIV(app)->item_current == svc_melodies_n) {
-		svc_lcd_puts(0, "----up");
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			PRIV(app)->item_current = 0;
-			app_exit();
-		}
-	}
-	else {
-		svc_lcd_puts(0, " pla");
-		svc_lcd_putsn(4, 2, svc_melodies[PRIV(app)->item_current].title);
-		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			svc_melody_play(PRIV(app)->item_current);
-		}
+
+	svc_lcd_puts(0, " pla");
+	svc_lcd_putsn(4, 2, svc_melodies[PRIV(app)->item_current].title);
+	if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
+		svc_melody_play(PRIV(app)->item_current);
 	}
 }
 

--- a/common/app/speed/app.c
+++ b/common/app/speed/app.c
@@ -30,7 +30,6 @@ static void distance_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item
 	svc_lcd_puti(0, 4, PRIV(app_current)->distance);
 };
 
-
 static int32_t distance_get(void *ud) {
 	return PRIV(app_current)->distance;
 }
@@ -49,8 +48,6 @@ static const svc_menu_item_adj_t menu_item_distance = {
 	.handler_set =  distance_set,
 	.handler_draw = distance_draw,
 };
-
-
 
 static void time_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, void *user_data) {
 	svc_lcd_puts(8, "ti");
@@ -82,7 +79,6 @@ static const svc_menu_item_text_t menu_item_time = {
 	.handler_draw = time_draw,
 	.handler = time_startstop,
 };
-
 
 static void speed_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, void *user_data) {
 	svc_lcd_puts(8, "km");
@@ -118,7 +114,6 @@ static const svc_menu_t menu = {
 	.header = "s ",
 	.header_pos = 8
 };
-
 
 static void main(uint8_t view, const app_t *app, svc_main_proc_event_t event) {
 	svc_menu_run(&menu, &(PRIV(app)->st), event);

--- a/common/app/speed/app.c
+++ b/common/app/speed/app.c
@@ -13,17 +13,10 @@ typedef struct {
 
 #define PRIV(a) ((priv_t*)((a)->priv))
 
-static void speed_exit(void *ud) {
+static void speed_exit(void) {
 	PRIV(app_current)->st.item_current = 0;
 	app_exit();
 }
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = speed_exit
-};
-
 
 static void distance_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, void *user_data) {
 	svc_lcd_puts(8,"di");
@@ -54,7 +47,7 @@ static void time_draw(svc_menu_state_t *state, svc_menu_item_unknown_t *item, vo
 	svc_chro_t ch;
 	svc_chro_get(1, &ch);
 	svc_chro_state_t st = svc_chro_get_state(1);
-	svc_lcd_puti(0, 2, ch.min); 
+	svc_lcd_puti(0, 2, ch.min);
 	svc_lcd_puti(2, 2, ch.sec);
 	uint16_t ss = (ch.subsec*100)/128;
 	svc_lcd_puti(4, 2, ss);
@@ -103,14 +96,13 @@ static const svc_menu_item_text_t menu_item_kmh = {
 static const svc_menu_item_text_t *menu_items[] = {
 	(void*)&menu_item_distance,
 	(void*)&menu_item_time,
-	(void*)&menu_item_kmh,
-	(void*)&menu_item_up,
+	(void*)&menu_item_kmh
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item_up,
+	.handler_exit = speed_exit,
 	.header = "s ",
 	.header_pos = 8
 };

--- a/common/app/time/acal.c
+++ b/common/app/time/acal.c
@@ -1,15 +1,8 @@
 #include "app.h"
 
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	app_set_view(app_current, 1);
 }
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
-};
-
 
 #define MEAS_INVALID 127
 static int8_t meas_delta = MEAS_INVALID;
@@ -132,14 +125,13 @@ static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_ssls,
 	(void*)&menu_item_ppm,
 	(void*)&menu_item_cal,
-	(void*)&menu_item_adj,
-	(void*)&menu_item_up,
+	(void*)&menu_item_adj
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item_up,
+	.handler_exit = menu_exit,
 	.header = "ac",
 	.header_pos = 8
 };

--- a/common/app/time/app.c
+++ b/common/app/time/app.c
@@ -134,6 +134,7 @@ static const svc_menu_item_adj_t menu_item_date = {
 	.handler_enter = adj_enter,
 	.handler_leave = adj_date_leave
 };
+
 static const svc_menu_item_choice_t menu_item_lang = {
 	.type = SVC_MENU_ITEM_T_CHOICE,
 	.text = "lang",
@@ -147,6 +148,7 @@ static const svc_menu_item_choice_t menu_item_lang = {
 	.handler_set = lang_set,
 	.handler_get = lang_get
 };
+
 static const svc_menu_item_choice_t menu_item_base = {
 	.type = SVC_MENU_ITEM_T_CHOICE,
 	.text = "base",

--- a/common/app/time/app.c
+++ b/common/app/time/app.c
@@ -1,7 +1,7 @@
 #include "app.h"
 #include "platform.h"
 
-static void menu_exit(void *ud) {
+static void menu_exit(void) {
 	app_set_view(app_current, 0);
 }
 
@@ -163,13 +163,6 @@ static const svc_menu_item_choice_t menu_item_base = {
 	.handler_get = base_get,
 };
 
-
-static const svc_menu_item_text_t menu_item_up = {
-	.type = SVC_MENU_ITEM_T_TEXT,
-	.text = "----up",
-	.handler = menu_exit
-};
-
 static int16_t cal_value = 0;
 static uint8_t cal_sign;
 
@@ -264,14 +257,13 @@ static const svc_menu_item_unknown_t *menu_items[] = {
 	(void*)&menu_item_lang,
 	(void*)&menu_item_adj,
 	(void*)&menu_item_cal,
-	(void*)&menu_item_cal_sign,
-	(void*)&menu_item_up,
+	(void*)&menu_item_cal_sign
 };
 
 static const svc_menu_t menu = {
 	.n_items = ARRAY_SIZE(menu_items),
 	.items = (void*)menu_items,
-	.item_up = (void*)&menu_item_up,
+	.handler_exit = menu_exit,
 	.header = "cf",
 	.header_pos = 8
 };

--- a/common/svc/countdown.c
+++ b/common/svc/countdown.c
@@ -17,7 +17,7 @@ typedef struct {
 
 static svc_countdown_priv_t SECTION_INFOMEM svc_countdowns[N_COUNTDOWNS] = {
 	{.h=0, .m=0, .s=5}
-	
+
 };
 
 #define NO_COUNTDOWN_PENDING 0xff
@@ -39,7 +39,7 @@ void svc_countdown_set_time(uint8_t index, uint8_t h, uint8_t m, uint8_t s) {
 	svc_countdowns[index].sm = m;
 	svc_countdowns[index].s = s;
 	svc_countdowns[index].ss = s;
-	
+
 }
 
 static void _svc_countdown_stop(svc_countdown_priv_t *cd) {
@@ -105,7 +105,6 @@ void svc_countdown_draw_popup(void) {
 			svc_lcd_puti(4, 2, countdown_pending);
 			svc_lcd_force_redraw();
 		}
-		
 	}
 	div = (div+1)%8;
 }

--- a/common/svc/menu.c
+++ b/common/svc/menu.c
@@ -14,13 +14,8 @@ void svc_menu_run(const svc_menu_t *menu, svc_menu_state_t *state, svc_main_proc
 			DEC_MOD(*item_current, menu->n_items);
 		}
 		else if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
-			if(menu->item_up) {
-				svc_menu_item_text_t *it = (void*)menu->item_up;
-				if(it->type == SVC_MENU_ITEM_T_TEXT) {
-					if(it->handler) {
-						it->handler(it->user_data);
-					}
-				}
+			if(menu->handler_exit) {
+				menu->handler_exit();
 			}
 		}
 		else if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
@@ -90,22 +85,15 @@ void svc_menu_run(const svc_menu_t *menu, svc_menu_state_t *state, svc_main_proc
 			state->adj_mode = 0;
 			return;
 		}
+
 		svc_lcd_puts(8, it->header);
-		if(event & (SVC_MAIN_PROC_EVENT_KEY_DOWN | SVC_MAIN_PROC_EVENT_KEY_UP)) {
-			if(state->adj_digit == it->digits) {
-				state->adj_mode = 0;
-				if(it->handler_leave) {
-					it->handler_leave(it->user_data);
-				}
-			}
-			if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
-				svc_lcd_blink_disable();
-				it->handler_set(it->digits-state->adj_digit-1, 1, it->user_data);
-			}
-			else {
-				svc_lcd_blink_disable();
-				it->handler_set(it->digits-state->adj_digit-1, -1, it->user_data);
-			}
+		if(event & SVC_MAIN_PROC_EVENT_KEY_UP) {
+			svc_lcd_blink_disable();
+			it->handler_set(it->digits-state->adj_digit-1, 1, it->user_data);
+		}
+		else if(event & SVC_MAIN_PROC_EVENT_KEY_DOWN) {
+			svc_lcd_blink_disable();
+			it->handler_set(it->digits-state->adj_digit-1, -1, it->user_data);
 		}
 
 		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER_LONG) {
@@ -117,14 +105,10 @@ void svc_menu_run(const svc_menu_t *menu, svc_menu_state_t *state, svc_main_proc
 
 		svc_lcd_puti(0, it->digits, it->handler_get(it->user_data));
 		if(event & SVC_MAIN_PROC_EVENT_KEY_ENTER) {
-			INC_MOD(state->adj_digit, it->digits+1);
+			INC_MOD(state->adj_digit, it->digits);
 		}
 		if(state->adj_digit < it->digits) {
 			hal_lcd_dig_set_blink_mask(1<<state->adj_digit);
-		}
-		else {
-			hal_lcd_dig_set_blink_mask((1<<4) | (1<<5));
-			svc_lcd_puts(0, "----up");
 		}
 	}
 }

--- a/common/svc/menu.h
+++ b/common/svc/menu.h
@@ -57,7 +57,7 @@ typedef struct {
 typedef struct {
 	uint8_t n_items;
 	svc_menu_item_unknown_t **items;
-	svc_menu_item_unknown_t *item_up;
+	void (*handler_exit)(void);
 	char *header;
 	uint8_t header_pos;
 } svc_menu_t;

--- a/sim/hal/pa-beep.c
+++ b/sim/hal/pa-beep.c
@@ -50,12 +50,12 @@ static void stream_request_cb(pa_stream *s, size_t length, void *userdata) {
   int neg;
   pa_stream_get_latency(s,&usec,&neg);
   //printf("  latency %8d us %d\n",(int)usec, length);
-  
+
   signed short *buf;
   size_t nb = length;
   pa_stream_begin_write(s, (void**)&buf, &nb);
   //printf("w %d %d\n", length, nb);
-  
+
   static unsigned short phase = 0;
   int i = 0;
   while(i < nb/2) {
@@ -67,11 +67,11 @@ static void stream_request_cb(pa_stream *s, size_t length, void *userdata) {
 		buf[i] = 0;
 		phase = 0;
 	}
-	  
+
 	  //printf("%d\n", buf[i]);
 	  i++;
   }
-  
+
   pa_stream_write(s, buf, nb, NULL, 0LL, PA_SEEK_RELATIVE);
 }
 
@@ -132,7 +132,7 @@ void beep_startup() {
   if (pa_ready == 2) {
     exit(-1);
   }
-  
+
   ss.rate = 48000;
   ss.channels = 1;
   ss.format = PA_SAMPLE_S16NE;

--- a/sim/hal/pa-beep.c
+++ b/sim/hal/pa-beep.c
@@ -83,7 +83,7 @@ static void stream_underflow_cb(pa_stream *s, void *userdata) {
   if (underflows >= 6 && latency < 2000000) {
     latency = (latency*3)/2;
     bufattr.maxlength = pa_usec_to_bytes(latency,&ss);
-    bufattr.tlength = pa_usec_to_bytes(latency,&ss);  
+    bufattr.tlength = pa_usec_to_bytes(latency,&ss);
     pa_stream_set_buffer_attr(s, &bufattr, NULL, NULL);
     underflows = 0;
     printf("latency increased to %d\n", latency);


### PR DESCRIPTION
Remove the 'up' menu entries. Going backwards can always be done via long press on enter key.